### PR TITLE
Maintenance

### DIFF
--- a/nue_asr/__init__.py
+++ b/nue_asr/__init__.py
@@ -1,3 +1,7 @@
+import logging
+
 from .model import NueASRConfig, NueASRModel  # noqa: F401
 from .transcribe import transcribe  # noqa: F401
 from .utils import load_model, load_tokenizer  # noqa: F401
+
+logging.getLogger(__name__)

--- a/nue_asr/transcribe.py
+++ b/nue_asr/transcribe.py
@@ -69,7 +69,7 @@ def transcribe(
         logger.warning(
             f"The input audio is {audio_len_sec:.1f} sec, "
             "but such long audio inputs may degrade recognition accuracy. "
-            "It is recommended to divide the audio into shorter segments."
+            "It is recommended to split the audio into shorter segments."
         )
 
     prefix_token = tokenizer.encode(

--- a/nue_asr/utils.py
+++ b/nue_asr/utils.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import random
-import warnings
 from typing import Optional, Union
 
 import numpy as np
@@ -23,6 +23,8 @@ from transformers import AutoTokenizer
 from .model import NueASRModel
 
 DEFAULT_MODEL_NAME = "rinna/nue-asr"
+
+logger = logging.getLogger(__name__)
 
 
 def str2bool(v: str):
@@ -62,15 +64,15 @@ def load_model(
     device = torch.device(device)
     if device.type == "cpu":
         if torch.cuda.is_available():
-            warnings.warn(
-                "CUDA is available but using CPU."
+            logging.warning(
+                "CUDA is available but using CPU. "
                 "If you want to use CUDA, set `device` to `cuda`."
             )
         if fp16:
-            warnings.warn("FP16 is not supported on CPU. Using FP32 instead.")
+            logging.warning("FP16 is not supported on CPU. Using FP32 instead.")
             fp16 = False
         if use_deepspeed:
-            warnings.warn("DeepSpeed is not supported on CPU. Disabling it.")
+            logging.warning("DeepSpeed is not supported on CPU. Disabling it.")
             use_deepspeed = False
 
     dtype = torch.float16 if fp16 else torch.float32
@@ -101,5 +103,7 @@ def load_model(
 
     if device is not None:
         model.to(device)
+
+    logger.info(f"Finished loading model from {model_name_or_path}")
 
     return model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools", "wheel"]
 
 [project]
-name = "rinnakk-nue-asr"
+name = "nue-asr"
 description = "An Integration of Pre-Trained Speech and Language Models for End-to-End Speech Recognition"
 version = "0.1.0"
 authors = [{ name = "rinna Co., Ltd." }]


### PR DESCRIPTION
- Change the project name from `rinnakk-nue-asr` to `nue-asr`
- Modify to output warnings using the logging framework
- Add a warning message when a long audio is input

**Important Note**: With the change the project name, those who have already installed the old `rinnakk-nue-asr` package should be uninstall it manually before updating.