### PR TITLE
Switch logging to utilize a custom logger

### DIFF
--- a/nue_asr/utils.py
+++ b/nue_asr/utils.py
@@ -64,15 +64,15 @@ def load_model(
     device = torch.device(device)
     if device.type == "cpu":
         if torch.cuda.is_available():
-            logging.warning(
+            logger.warning(
                 "CUDA is available but using CPU. "
                 "If you want to use CUDA, set `device` to `cuda`."
             )
         if fp16:
-            logging.warning("FP16 is not supported on CPU. Using FP32 instead.")
+            logger.warning("FP16 is not supported on CPU. Using FP32 instead.")
             fp16 = False
         if use_deepspeed:
-            logging.warning("DeepSpeed is not supported on CPU. Disabling it.")
+            logger.warning("DeepSpeed is not supported on CPU. Disabling it.")
             use_deepspeed = False
 
     dtype = torch.float16 if fp16 else torch.float32


### PR DESCRIPTION
This is a small patch that improves Nue's logging system.

* Make sure that log messages are sent through Nue's own logger,
   instead of using the root logger directly.

* With this applied, we can suppress Nue's logs/warnings very easily.

The following snippet shows how this commit can be used:

```python3
import logging
import nue_asr

logging.getLogger('nue_asr').setLevel(logging.ERROR)
model = nue_asr.load_model("rinna/nue-asr", device="cpu")
...
```