### PR TITLE
Remove bogus getLogger() call in __init__.py

### DIFF
--- a/nue_asr/__init__.py
+++ b/nue_asr/__init__.py
@@ -3,5 +3,3 @@ import logging
 from .model import NueASRConfig, NueASRModel  # noqa: F401
 from .transcribe import transcribe  # noqa: F401
 from .utils import load_model, load_tokenizer  # noqa: F401
-
-logging.getLogger(__name__)


### PR DESCRIPTION
While checking the logging code in #2, I notice that there is a
line that calls `getLogger()` for no reason.

It's very likely an unintended artifact. Remove it.